### PR TITLE
fix(types): use named export to resolve ESLint error

### DIFF
--- a/src/dither/dither.ts
+++ b/src/dither/dither.ts
@@ -313,7 +313,7 @@ const getPresetDefaults = (presetName: ProcessingPresetName | undefined) => {
   } satisfies Partial<DitherImageOptions>;
 };
 
-const dither = async (
+const ditherImage = async (
   sourceCanvas: CanvasLike,
   canvas: CanvasLike,
   opts: DitherImageOptions = {}
@@ -600,4 +600,4 @@ const imageDataToCanvas = (imageData: ImageDataLike, canvas: CanvasLike) => {
   return canvas;
 };
 
-export default dither;
+export {ditherImage};

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ export type {
   ReplaceColorsPalette,
 } from "./replaceColors/replaceColors";
 
-export { default as ditherImage } from "./dither/dither";
+export { ditherImage } from "./dither/dither";
 export {
   getProcessingPreset,
   getProcessingPresetNames,


### PR DESCRIPTION
an error:
```
ESLint: Unsafe call of a type that could not be resolved. (@typescript-eslint/no-unsafe-call)
```


<img width="781" height="283" alt="Screenshot 2026-04-21 at 21 32 19" src="https://github.com/user-attachments/assets/695b26ef-7934-4d0e-94c6-35e00869be20" />
